### PR TITLE
Allow specifying of command by args

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,16 @@ Key features of `evry` are:
 $ [STDIN] | evry [-l N or -s N] -c [COMMAND]
 ```
 
+or
+
+``` console
+$ [STDIN] | evry [-l N or -s N] -- [COMMAND]
+```
+
 ### Count number of requests every 10 seconds
 
 ``` console
-$ tail -F access.log | evry -s 10 -c 'wc -l'
+$ tail -F access.log | evry -s 10 -- wc -l
 ```
 
 ### Show top 5 access rank every 1000 lines

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -73,8 +73,13 @@ var rootCmd = &cobra.Command{
 		ctx := context.Background()
 		var s splitter.Splitter
 		var err error
+		var c []string
 
-		c := []string{"sh", "-c", command}
+		if len(args) > 0 {
+			c = args
+		} else {
+			c = []string{"sh", "-c", command}
+		}
 
 		if line > 0 {
 			s, err = splitter.NewLineSplitter(ctx, line, c, timeout)

--- a/evry_test.go
+++ b/evry_test.go
@@ -55,6 +55,15 @@ func TestPipe(t *testing.T) {
 	}
 }
 
+func TestPipeWithArgs(t *testing.T) {
+	cmd := `echo -e "b\nc\na\ne\nd" | ./evry -l 10 -- sh -c 'cat | sort | head -3'`
+	want := "a\nb\nc\n"
+	got := execCmd(cmd)
+	if got != want {
+		t.Errorf("\nwant %q\ngot  %q", want, got)
+	}
+}
+
 func execCmd(cmd string) string {
 	b, _ := exec.Command(os.Getenv("SHELL"), "-c", cmd).Output()
 	return string(b)


### PR DESCRIPTION
Allow specifying of command by args, following

``` console
$ tail -F access.log | evry -s 10 -- wc -l
```